### PR TITLE
Permadeath

### DIFF
--- a/bundles/myelin-classes/effects/skill.claw.js
+++ b/bundles/myelin-classes/effects/skill.claw.js
@@ -36,7 +36,9 @@ module.exports = srcPath => {
       },
 
       killed: function () {
-        this.remove();
+        if (this.target.isNpc) {
+          this.remove();
+        }
       }
     }
   };

--- a/bundles/myelin-input-events/backgrounds/urchin.yml
+++ b/bundles/myelin-input-events/backgrounds/urchin.yml
@@ -4,9 +4,9 @@ description: "Having to fight and steal to survive will toughen one's body and s
 karmaLevel: 0
 attributes:
   quickness: 16
-  intellect: 9
+  intellect: 8
   might: 7
-  willpower: 14
+  willpower: 9
 equipment: ['spire.intro:9', 'spire.intro:10', 'spire.intro:11']
 skills: [ 'lunge' ]
 attributePoints: 1

--- a/bundles/myelin-input-events/input-events/choose-character.js
+++ b/bundles/myelin-input-events/input-events/choose-character.js
@@ -74,7 +74,9 @@ module.exports = (srcPath) => {
             display: dec,
             onSelect: () => {
               //TODO: Make an input event for this ayyy
+              args.name = dec;
               console.log('they ded lol');
+              socket.emit('memorial', socket, args);
             }
           })
         })

--- a/bundles/myelin-input-events/input-events/choose-character.js
+++ b/bundles/myelin-input-events/input-events/choose-character.js
@@ -66,6 +66,7 @@ module.exports = (srcPath) => {
         });
       }
 
+      //TODO: Should maybe be a submenu since they gon die a lot maybe.
       if (deceased.length) {
         options.push({ display: "View Memorials:" });
         deceased.forEach(dec => {

--- a/bundles/myelin-input-events/input-events/choose-character.js
+++ b/bundles/myelin-input-events/input-events/choose-character.js
@@ -73,9 +73,7 @@ module.exports = (srcPath) => {
           options.push({
             display: dec,
             onSelect: () => {
-              //TODO: Make an input event for this ayyy
               args.name = dec;
-              console.log('they ded lol');
               socket.emit('memorial', socket, args);
             }
           })

--- a/bundles/myelin-input-events/input-events/choose-character.js
+++ b/bundles/myelin-input-events/input-events/choose-character.js
@@ -26,11 +26,11 @@ module.exports = (srcPath) => {
 
       // This just gets their names.
       const characters = account.characters;
+      const deceased = account.getMeta('deceased') || [];
 
       const maxCharacters   = Config.get("maxCharacters");
       const canAddCharacter = characters.length < maxCharacters;
       const canMultiplay    = Config.get("allowMultiplay");
-
 
       let options = [];
 
@@ -64,6 +64,19 @@ module.exports = (srcPath) => {
             },
           });
         });
+      }
+
+      if (deceased.length) {
+        options.push({ display: "View Memorials:" });
+        deceased.forEach(dec => {
+          options.push({
+            display: dec,
+            onSelect: () => {
+              //TODO: Make an input event for this ayyy
+              console.log('they ded lol');
+            }
+          })
+        })
       }
 
       /*

--- a/bundles/myelin-input-events/input-events/memorial.js
+++ b/bundles/myelin-input-events/input-events/memorial.js
@@ -41,6 +41,7 @@ module.exports = (srcPath) => {
       if (effects.length) {
         say("Died under the effects of: ");
         effects.forEach(effect => write(`${effect.config.name} | `));
+        say("")
       }
       say("Press enter to pay respects.");
 

--- a/bundles/myelin-input-events/input-events/memorial.js
+++ b/bundles/myelin-input-events/input-events/memorial.js
@@ -12,6 +12,7 @@ module.exports = (srcPath) => {
     event: state => (socket, args) => {
       let { name } = args;
       const say = EventUtil.genSay(socket);
+      const write = EventUtil.genWrite(socket);
 
       // Get pfile of deceased to show stats.
       const deceased = Data.load('player', name);
@@ -20,6 +21,7 @@ module.exports = (srcPath) => {
       const timeSinceDeath = killedOn ?
         humanizeDuration(Date.now() - killedOn, { largest: 2, round: true }) :
         'a long time';
+      const effects = deceased.effects;
 
       const killerName = killedBy === name ? 'a lethal condition' : killedBy;
 
@@ -35,6 +37,11 @@ module.exports = (srcPath) => {
       say("------------------------------");
       say(`Killed by ${killerName || "something unknown"}.`);
       say(`Died ${timeSinceDeath} ago.`);
+      say("------------------------------");
+      if (effects.length) {
+        say("Died under the effects of: ");
+        effects.forEach(effect => write(`${effect.config.name} | `));
+      }
       say("Press enter to pay respects.");
 
       socket.once('data', _ => {

--- a/bundles/myelin-input-events/input-events/memorial.js
+++ b/bundles/myelin-input-events/input-events/memorial.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/**
+ * Account character selection event
+ */
+module.exports = (srcPath) => {
+  const Broadcast = require(srcPath + 'Broadcast');
+  const EventUtil = require(srcPath + 'EventUtil');
+  const Config    = require(srcPath + 'Config');
+  const Logger    = require(srcPath + 'Logger');
+
+  return {
+    event: state => (socket, args) => {
+      let { name } = args;
+      const say = EventUtil.genSay(socket);
+
+      // Get pfile of deceased to show stats.
+
+      say("\r\n------------------------------");
+      say("|      " + name);
+      say("------------------------------");
+      say("Press enter to pay respects.");
+
+
+      socket.once('data', _ => {
+        return socket.emit('choose-character', socket, args);
+      });
+    }
+  };
+};

--- a/bundles/myelin-input-events/input-events/memorial.js
+++ b/bundles/myelin-input-events/input-events/memorial.js
@@ -35,13 +35,16 @@ module.exports = (srcPath) => {
       say(`| Quickness: ${attrs.quickness.base}`);
       say(`| Might: ${attrs.might.base}`);
       say("------------------------------");
-      say(`Killed by ${killerName || "something unknown"}.`);
-      say(`Died ${timeSinceDeath} ago.`);
+      say(`| Killed by ${killerName || "something unknown"}.`);
+      say(`| Died ${timeSinceDeath} ago.`);
       say("------------------------------");
       if (effects.length) {
-        say("Died under the effects of: ");
-        effects.forEach(effect => write(`${effect.config.name} | `));
-        say("")
+        say("| Died under the effects of: ");
+        effects.forEach((effect, i) => {
+          const put = i % 3 ? say : write;
+          put(`| ${effect.config.name} `);
+        });
+        say("------------------------------");
       }
       say("Press enter to pay respects.");
 

--- a/bundles/myelin-input-events/input-events/memorial.js
+++ b/bundles/myelin-input-events/input-events/memorial.js
@@ -44,7 +44,11 @@ module.exports = (srcPath) => {
           const put = i % 3 ? say : write;
           put(`| ${effect.config.name} `);
         });
-        say("------------------------------");
+        if (effects.length % 2 === 0) {
+          say("------------------------------");
+        } else {
+          say("\r\n------------------------------");
+        }
       }
       say("Press enter to pay respects.");
 

--- a/bundles/myelin-input-events/input-events/memorial.js
+++ b/bundles/myelin-input-events/input-events/memorial.js
@@ -4,10 +4,9 @@
  * Account character selection event
  */
 module.exports = (srcPath) => {
-  const Broadcast = require(srcPath + 'Broadcast');
   const EventUtil = require(srcPath + 'EventUtil');
-  const Config    = require(srcPath + 'Config');
-  const Logger    = require(srcPath + 'Logger');
+  const Data = require(srcPath + 'Data');
+  const humanizeDuration = require('humanize-duration');
 
   return {
     event: state => (socket, args) => {
@@ -15,12 +14,28 @@ module.exports = (srcPath) => {
       const say = EventUtil.genSay(socket);
 
       // Get pfile of deceased to show stats.
+      const deceased = Data.load('player', name);
+      const attrs = deceased.attributes;
+      const { killedOn, killedBy } = deceased.metadata;
+      const timeSinceDeath = killedOn ?
+        humanizeDuration(Date.now() - killedOn, { largest: 2, round: true }) :
+        'a long time';
 
+      const killerName = killedBy === name ? 'a lethal condition' : killedBy;
+
+      // Display relevant stats and info re: death.
       say("\r\n------------------------------");
       say("|      " + name);
       say("------------------------------");
+      say(`| Level: ${deceased.level}`);
+      say(`| Willpower: ${attrs.willpower.base}`);
+      say(`| Intellect: ${attrs.intellect.base}`);
+      say(`| Quickness: ${attrs.quickness.base}`);
+      say(`| Might: ${attrs.might.base}`);
+      say("------------------------------");
+      say(`Killed by ${killerName || "something unknown"}.`);
+      say(`Died ${timeSinceDeath} ago.`);
       say("Press enter to pay respects.");
-
 
       socket.once('data', _ => {
         return socket.emit('choose-character', socket, args);

--- a/bundles/ranvier-combat/player-events.js
+++ b/bundles/ranvier-combat/player-events.js
@@ -343,7 +343,8 @@ module.exports = (srcPath) => {
           maxItems: items.length + 1,
           behaviors: {
             decay: {
-              duration: 600
+              // To prevent killing yourself to harvest own items.
+              duration: this.level < 4 ? 30 : 600
             }
           },
         });

--- a/bundles/ranvier-combat/player-events.js
+++ b/bundles/ranvier-combat/player-events.js
@@ -375,13 +375,10 @@ module.exports = (srcPath) => {
 
         // Add deceased char's name to account list of deceased, and remove from characters.
         const alreadyDeceased = this.account.getMeta('deceased') || [];
-        this.account.setMeta('deceased', alreadyDeceased.push(this.name));
+        this.account.setMeta('deceased', alreadyDeceased.concat(this.name));
         this.account.characters = this.account.characters.filter(name => name !== this.name);
 
-        // Save account.
         this.account.save();
-
-        // Serialize some of player's info into deceased dir.
 
       },
 

--- a/bundles/ranvier-combat/player-events.js
+++ b/bundles/ranvier-combat/player-events.js
@@ -351,14 +351,15 @@ module.exports = (srcPath) => {
 
         Logger.log(`Generated corpse: ${corpse.uuid}`);
 
-
-
         items.forEach(item => {
           item.hydrate(state);
           corpse.addItem(item)
         });
         this.room.addItem(corpse);
         state.ItemManager.add(corpse);
+
+        this.setMeta('killedBy', killer ? killer.name : 'something unknown');
+        this.setMeta('killedOn', Date.now());
 
         // Disconnect player.
         this.save(() => {

--- a/bundles/ranvier-combat/player-events.js
+++ b/bundles/ranvier-combat/player-events.js
@@ -458,7 +458,7 @@ module.exports = (srcPath) => {
 
     deadEntity.emit('killed', killer || deadEntity);
 
-    if (!killer.isNpc) {
+    if (killer && !killer.isNpc) {
       if (killer.party) {
         for (const member of killer.party) {
           B.prompt(member);

--- a/bundles/ranvier-combat/player-events.js
+++ b/bundles/ranvier-combat/player-events.js
@@ -319,6 +319,16 @@ module.exports = (srcPath) => {
 
         B.sayAt(this, '<b><red>You have died. You feel the last of your essence slipping from this mortal husk.</red></b>');
 
+        const items = [];
+
+        if (this.inventory) {
+          items.push(...this.inventory.values());
+        }
+
+        if (this.equipment) {
+          items.push(...this.equipment.values());
+        }
+
         // Make and drop a corpse w/ player inventory/equipment.
         const corpse = new Item(this.area, {
           id: 'corpse',
@@ -330,7 +340,7 @@ module.exports = (srcPath) => {
           properties: {
             noPickup: true,
           },
-          maxItems: this.inventory.size + this.equipment.size + 1,
+          maxItems: items.length + 1,
           behaviors: {
             decay: {
               duration: 600
@@ -341,10 +351,7 @@ module.exports = (srcPath) => {
 
         Logger.log(`Generated corpse: ${corpse.uuid}`);
 
-        const items = [
-          ...this.inventory.values(),
-          ...this.equipment.values()
-        ];
+
 
         items.forEach(item => {
           item.hydrate(state);

--- a/src/Account.js
+++ b/src/Account.js
@@ -46,11 +46,11 @@ class Account {
   }
 
   setMeta(key, value) {
-    this.data[key] = value;
+    this.meta[key] = value;
   }
 
   getMeta(key) {
-    return this.data[key];
+    return this.meta[key];
   }
 
   _hashPassword(pass) {

--- a/src/Account.js
+++ b/src/Account.js
@@ -10,7 +10,7 @@ class Account {
     this.characters = data.characters || [];
     this.password   = data.password;
     this.meta       = data.meta || { karma: 0 };
-    this.banned = data.banned || false;
+    this.banned     = data.banned || false;
   }
 
   getUsername() {


### PR DESCRIPTION
- Player is disconnected when they die, eventually might kick them back to a menu instead. 
- Addition of "karma" to be spent during chargen for new characters. (unimplemented as of yet)
- Player name is moved from account.characters to account.deceased. This could lead to clutter but can be optimized later. For now the entire deceased pfile is kept.
- Menu option to view memorials of deceased characters with basic stats and facts about their death.
- Players leave a corpse with all items and equipment that persists slightly longer than the average corpse. Might have to change that to prevent abuse (e.g., starting a new character of one background, committing suicide, starting a new character of a different background and looting the previous corpse).